### PR TITLE
chore(ci): Remove conda cache from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: generic
 cache:
   directories:
     - $HOME/.cache/Tectonic
-    - $HOME/miniconda
 
 jobs:
   include:


### PR DESCRIPTION
This is causing a range of build failures